### PR TITLE
Fix int to enum equality check for Android implementation

### DIFF
--- a/Assets/Smartlook/SmartlookAnalytics/Scripts/Smartlook.Android.cs
+++ b/Assets/Smartlook/SmartlookAnalytics/Scripts/Smartlook.Android.cs
@@ -107,7 +107,7 @@ namespace SmartlookUnity
             {
                 string internalDirection = "start";
 
-                if (direction.Equals(NavigationEventType.exit))
+                if (((NavigationEventType)direction).Equals(NavigationEventType.exit))
                 {
                     internalDirection = "stop";
                 }
@@ -235,7 +235,7 @@ namespace SmartlookUnity
             {
                 string internalRenderingMode = "native";
 
-                if (renderingMode.Equals(RenderingModeType.no_rendering))
+                if (((RenderingModeType)renderingMode).Equals(RenderingModeType.no_rendering))
                 {
                     internalRenderingMode = "no_rendering";
                 }


### PR DESCRIPTION
In the `Smartlook.Android` class there's a few equality checks with integers against enum values. This check will always return false.

E.g.
```
var renderingMode = 1;

if (renderingMode.Equals(RenderingModeType.no_rendering)) {
   // This will never be called, because the above statement is always false
}
```

Casting the integer back to the enum value will fix the issue.